### PR TITLE
Remove double-slashes in URL paths

### DIFF
--- a/_layouts/projects.html
+++ b/_layouts/projects.html
@@ -25,9 +25,9 @@ layout: default
 
 
 <div class="tile tile--project col-xs-12 col-sm-10 col-sm-offset-1 col-md-offset-0 col-md-4">
-  <a class="tile-link"  href="http://projects.austintexas.io//projects/austin-digital-services-discovery/" title="Digital Services Transformation"></a>
+  <a class="tile-link"  href="http://projects.austintexas.io/projects/austin-digital-services-discovery/" title="Digital Services Transformation"></a>
   <div class="tile-outline">
-    <div class="tile-img" style="background-image: url('http://projects.austintexas.io//assets/img/projects/digital-services-discovery/techstack.jpg')"></div>
+    <div class="tile-img" style="background-image: url('http://projects.austintexas.io/assets/img/projects/digital-services-discovery/techstack.jpg')"></div>
     <div class="tile-text">
       <h3 class="tile-title">
         Digital Services Transformation
@@ -45,9 +45,9 @@ layout: default
 
 
 <div class="tile tile--project col-xs-12 col-sm-10 col-sm-offset-1 col-md-offset-0 col-md-4">
-  <a class="tile-link"  href="http://projects.austintexas.io//projects/permitting-initiative/" title="Making Permitting Work for Austin"></a>
+  <a class="tile-link"  href="http://projects.austintexas.io/projects/permitting-initiative/" title="Making Permitting Work for Austin"></a>
   <div class="tile-outline">
-    <div class="tile-img" style="background-image: url('http://projects.austintexas.io//assets/img/projects/permitting/permitting.png')"></div>
+    <div class="tile-img" style="background-image: url('http://projects.austintexas.io/assets/img/projects/permitting/permitting.png')"></div>
     <div class="tile-text">
       <h3 class="tile-title">
         Making Permitting Work for Austin
@@ -67,7 +67,7 @@ layout: default
 <div class="tile tile--project col-xs-12 col-sm-10 col-sm-offset-1 col-md-offset-0 col-md-4">
   <a class="tile-link"  href="http://projects.austintexas.io/projects/atxfloods/" title="Improving Alerts for Flooded Roadways"></a>
   <div class="tile-outline">
-    <div class="tile-img" style="background-image: url('http://projects.austintexas.io//assets/img/projects/atxfloods/atxfloods.jpg')"></div>
+    <div class="tile-img" style="background-image: url('http://projects.austintexas.io/assets/img/projects/atxfloods/atxfloods.jpg')"></div>
     <div class="tile-text">
       <h3 class="tile-title">
         Improving Alerts for Flooded Roadways
@@ -84,9 +84,9 @@ layout: default
 </div>
 
 <div class="tile tile--project col-xs-12 col-sm-10 col-sm-offset-1 col-md-offset-0 col-md-4">
-  <a class="tile-link"  href="http://projects.austintexas.io//projects/SUMMITweek-Winter-2018/" title="SUMMITweek Winter 2018"></a>
+  <a class="tile-link"  href="http://projects.austintexas.io/projects/SUMMITweek-Winter-2018/" title="SUMMITweek Winter 2018"></a>
   <div class="tile-outline">
-    <div class="tile-img" style="background-image: url('http://projects.austintexas.io//assets/img/projects/SUMMITweek-Winter-2018/summitweek-logo.jpg')"></div>
+    <div class="tile-img" style="background-image: url('http://projects.austintexas.io/assets/img/projects/SUMMITweek-Winter-2018/summitweek-logo.jpg')"></div>
     <div class="tile-text">
       <h3 class="tile-title">
         SUMMITweek Winter 2018


### PR DESCRIPTION
Several URLs had double slashes in their paths, which are not necessary. This PR removes them.