### PR TITLE
fix: small syntax issue and paid sick leave information

### DIFF
--- a/_jobs/information/benefits.md
+++ b/_jobs/information/benefits.md
@@ -34,4 +34,4 @@ Temporary positions at the City of Austin are not eligible for holidays or other
 The lack of paid time off can be significant inconvenience for all of us, so we encourage our employees to flex their hours over the course of each two-week pay period (for example, working 48 hours during the first week and 32 hours the following week). Temporary employees can also choose to take unpaid leave as needed.
 
 ### Insurance
-Temporary positions at the City of Austin are not be eligible for health insurance for the first year. Our employees who work beyond their initial one-year term become eligible for health insurance from the City in their second year.
+Temporary positions at the City of Austin are not eligible for health insurance for the first year. Our employees who work beyond their initial one-year term become eligible for health insurance from the City in their second year.


### PR DESCRIPTION
One more little syntax fix.

A couple additional notes besides:

1) The link to the Statesman article regarding paid sick leave is broken and should point instead to <https://www.statesman.com/news/20180217/austin-becomes-1st-city-in-texas-to-mandate-paid-sick-leave>.
2) That said, the underlying ordinance is still in legal limbo so perhaps this section will require some more context: <https://www.statesman.com/news/20181116/appeals-court-voids-austins-paid-sick-leave-ordinance>.